### PR TITLE
feat(frontend): add lib/session.server.ts and wire session into root loader

### DIFF
--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -15,9 +15,11 @@ import {
 import type { Route } from "./+types/root";
 import Header from "@/components/layout/Header";
 import Footer from "@/components/layout/Footer";
+import { getSession } from "@/lib/session.server";
 
-export async function loader(): Promise<{ user: null }> {
-  return { user: null };
+export async function loader({ request }: Route.LoaderArgs) {
+  const session = await getSession(request);
+  return { user: session?.user ?? null };
 }
 
 export function Layout({ children }: { children: React.ReactNode }) {

--- a/frontend/lib/session.server.ts
+++ b/frontend/lib/session.server.ts
@@ -1,0 +1,60 @@
+import type { AuthUser } from "@skillity/shared";
+import { serverGet } from "@/lib/api-client.server";
+
+const API_URL = process.env.API_URL ?? "http://localhost:3000";
+
+function getCookieValue(cookieHeader: string, name: string): string | null {
+  const match = cookieHeader.match(new RegExp(`(?:^|;\\s*)${name}=([^;]*)`));
+  return match ? match[1] : null;
+}
+
+async function tryRefreshAndGetMe(cookieHeader: string): Promise<{ user: AuthUser } | null> {
+  const refreshToken = getCookieValue(cookieHeader, "refresh_token");
+  if (!refreshToken) return null;
+
+  try {
+    const refreshResponse = await fetch(`${API_URL}/auth/refresh`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `refresh_token=${refreshToken}`,
+      },
+    });
+
+    if (!refreshResponse.ok) return null;
+
+    const newCookies = refreshResponse.headers.getSetCookie();
+    const forwardCookie = newCookies.map((c) => c.split(";")[0]).join("; ");
+
+    const meResponse = await fetch(`${API_URL}/auth/me`, {
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: forwardCookie,
+      },
+    });
+
+    if (!meResponse.ok) return null;
+    return meResponse.json();
+  } catch {
+    return null;
+  }
+}
+
+export async function getSession(request: Request): Promise<{ user: AuthUser } | null> {
+  const cookieHeader = request.headers.get("cookie") ?? "";
+  const hasAuth =
+    cookieHeader.includes("access_token=") || cookieHeader.includes("refresh_token=");
+
+  if (!hasAuth) return null;
+
+  try {
+    return await serverGet<{ user: AuthUser }>("/auth/me", request);
+  } catch {
+    return tryRefreshAndGetMe(cookieHeader);
+  }
+}
+
+export async function getCurrentUser(request: Request): Promise<AuthUser | null> {
+  const session = await getSession(request);
+  return session?.user ?? null;
+}


### PR DESCRIPTION
Closes #5

Ports `data/auth.ts` `getSession()` to `lib/session.server.ts`. Function now accepts `Request` instead of using `next/headers` `cookies()`. Root loader calls `getSession(request)` — Header now reflects real auth state.