### PR TITLE
feat(bookings): Mollie payment fields + migration CLI fix (#44 #45)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -9,10 +9,10 @@
     "start:dev": "bun --watch src/main.ts",
     "build": "bun build ./src/main.ts --outdir ./dist",
     "test": "bun test",
-    "migration:generate": "bunx typeorm migration:generate -d data-source.ts",
-    "migration:run": "bunx typeorm migration:run -d data-source.ts",
-    "migration:revert": "bunx typeorm migration:revert -d data-source.ts",
-    "migration:create": "bunx typeorm migration:create",
+    "migration:generate": "bun ./node_modules/typeorm/cli.js migration:generate -d data-source.ts",
+    "migration:run": "bun ./node_modules/typeorm/cli.js migration:run -d data-source.ts",
+    "migration:revert": "bun ./node_modules/typeorm/cli.js migration:revert -d data-source.ts",
+    "migration:create": "bun ./node_modules/typeorm/cli.js migration:create",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/backend/src/bookings/bookings.service.ts
+++ b/backend/src/bookings/bookings.service.ts
@@ -128,7 +128,6 @@ export class BookingsService {
       }
 
       booking.status = BookingStatus.CONFIRMED;
-      booking.paymentId = `mock_${Date.now()}`;
 
       return manager.save(booking);
     });

--- a/backend/src/bookings/entities/booking.entity.ts
+++ b/backend/src/bookings/entities/booking.entity.ts
@@ -17,8 +17,11 @@ export class Booking extends BaseEntity {
   @Column({ name: 'workshop_id' })
   workshopId: string;
 
-  @Column({ name: 'payment_id', nullable: true })
-  paymentId: string | null;
+  @Column({ name: 'mollie_payment_id', nullable: true })
+  molliePaymentId: string | null;
+
+  @Column({ name: 'paid_at', type: 'timestamp', nullable: true })
+  paidAt: Date | null;
 
   @Column({ type: 'decimal', precision: 10, scale: 2 })
   amount: number;

--- a/backend/src/migrations/1774706480182-AddMollieFieldsToBooking.ts
+++ b/backend/src/migrations/1774706480182-AddMollieFieldsToBooking.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddMollieFieldsToBooking1774706480182 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "booking" RENAME COLUMN "payment_id" TO "mollie_payment_id"`);
+        await queryRunner.query(`ALTER TABLE "booking" ADD COLUMN "paid_at" TIMESTAMP`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "booking" DROP COLUMN "paid_at"`);
+        await queryRunner.query(`ALTER TABLE "booking" RENAME COLUMN "mollie_payment_id" TO "payment_id"`);
+    }
+
+}

--- a/packages/shared/src/types/booking.ts
+++ b/packages/shared/src/types/booking.ts
@@ -13,7 +13,8 @@ export interface Booking {
   userId: string;
   workshopId: string;
   workshop: Workshop;
-  paymentId: string | null;
+  molliePaymentId: string | null;
+  paidAt: string | null;
   amount: number;
   currency: string;
   createdAt: string;


### PR DESCRIPTION
## Summary
- Renames `paymentId` → `molliePaymentId` and adds `paidAt` timestamp to `Booking` entity (matching Mollie's payment object field names)
- Removes mock `payment_id = mock_${Date.now()}` assignment from `confirmBooking` — field is now null until real Mollie payment lands
- Shared `Booking` type updated to match
- Migration included for production (`payment_id` column rename + `paid_at` add)
- Fixes `migration:*` scripts to use `bun ./node_modules/typeorm/cli.js` so TypeScript path aliases resolve correctly under Bun

## Notes
- App works identically — `molliePaymentId` is nullable, bookings still confirm fine
- The migration CLI fix on this branch should land before #117 (which branches off main before this fix)

## Test plan
- [ ] Confirm a booking — should succeed, `molliePaymentId` is null (not mock string)
- [ ] `bun run migration:generate` should work without TypeScript errors