### PR TITLE
feat(workshops): location autocomplete via Nominatim (#117)

### DIFF
--- a/backend/src/migrations/1774706842819-AddLocationCoordsToWorkshop.ts
+++ b/backend/src/migrations/1774706842819-AddLocationCoordsToWorkshop.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddLocationCoordsToWorkshop1774706842819 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "workshop" ADD COLUMN "location_lat" DECIMAL(9,6)`);
+        await queryRunner.query(`ALTER TABLE "workshop" ADD COLUMN "location_lng" DECIMAL(9,6)`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "workshop" DROP COLUMN "location_lat"`);
+        await queryRunner.query(`ALTER TABLE "workshop" DROP COLUMN "location_lng"`);
+    }
+
+}

--- a/backend/src/workshops/dto/create-workshop.dto.ts
+++ b/backend/src/workshops/dto/create-workshop.dto.ts
@@ -12,6 +12,8 @@ import {
   IsUrl,
   IsEnum,
   IsUUID,
+  IsLatitude,
+  IsLongitude,
 } from 'class-validator';
 import {
   WorkshopCategory,
@@ -49,6 +51,14 @@ export class CreateWorkshopDto {
   @IsString()
   @IsNotEmpty()
   location: string;
+
+  @IsOptional()
+  @IsLatitude()
+  locationLat?: number;
+
+  @IsOptional()
+  @IsLongitude()
+  locationLng?: number;
 
   @IsDateString()
   @IsNotEmpty()

--- a/backend/src/workshops/entities/workshop.entity.ts
+++ b/backend/src/workshops/entities/workshop.entity.ts
@@ -29,6 +29,12 @@ export class Workshop extends BaseEntity {
   @Column()
   location: string;
 
+  @Column({ name: 'location_lat', type: 'decimal', precision: 9, scale: 6, nullable: true })
+  locationLat: number | null;
+
+  @Column({ name: 'location_lng', type: 'decimal', precision: 9, scale: 6, nullable: true })
+  locationLng: number | null;
+
   @Column({ name: 'starts_at', type: 'timestamp', nullable: true })
   startsAt: Date;
 

--- a/frontend/components/ui/location-autocomplete.tsx
+++ b/frontend/components/ui/location-autocomplete.tsx
@@ -1,0 +1,113 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+
+interface NominatimResult {
+  place_id: number;
+  display_name: string;
+  lat: string;
+  lon: string;
+}
+
+interface LocationAutocompleteProps {
+  value: string;
+  onChange: (value: string) => void;
+  onCoordinatesChange?: (lat: number, lng: number) => void;
+  placeholder?: string;
+  id?: string;
+  className?: string;
+}
+
+export default function LocationAutocomplete({
+  value,
+  onChange,
+  onCoordinatesChange,
+  placeholder,
+  id,
+  className,
+}: LocationAutocompleteProps) {
+  const [suggestions, setSuggestions] = useState<NominatimResult[]>([]);
+  const [open, setOpen] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const search = useCallback(async (query: string) => {
+    if (query.length < 3) {
+      setSuggestions([]);
+      setOpen(false);
+      return;
+    }
+    const params = new URLSearchParams({
+      q: query,
+      format: 'json',
+      limit: '5',
+      countrycodes: 'de',
+    });
+    try {
+      const res = await fetch(`https://nominatim.openstreetmap.org/search?${params}`);
+      const data: NominatimResult[] = await res.json();
+      setSuggestions(data);
+      setOpen(data.length > 0);
+    } catch {
+      setSuggestions([]);
+    }
+  }, []);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const next = e.target.value;
+    onChange(next);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => search(next), 500);
+  };
+
+  const handleSelect = (result: NominatimResult) => {
+    onChange(result.display_name);
+    onCoordinatesChange?.(parseFloat(result.lat), parseFloat(result.lon));
+    setSuggestions([]);
+    setOpen(false);
+  };
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  return (
+    <div ref={containerRef} className={cn('relative', className)}>
+      <Input
+        id={id}
+        value={value}
+        onChange={handleInputChange}
+        placeholder={placeholder}
+        autoComplete="off"
+      />
+      {open && suggestions.length > 0 && (
+        <ul className="absolute z-50 mt-1 w-full rounded-md border bg-popover shadow-md overflow-hidden">
+          {suggestions.map((result) => (
+            <li
+              key={result.place_id}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                handleSelect(result);
+              }}
+              className="cursor-pointer px-3 py-2 text-sm hover:bg-accent truncate"
+            >
+              {result.display_name}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/workshops/CreateWorkshopForm.tsx
+++ b/frontend/components/workshops/CreateWorkshopForm.tsx
@@ -6,6 +6,7 @@ import { CalendarIcon, Check } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import LocationAutocomplete from '@/components/ui/location-autocomplete';
 import { Textarea } from '@/components/ui/textarea';
 import { Calendar } from '@/components/ui/calendar';
 import {
@@ -38,6 +39,8 @@ interface FormValues {
   maxParticipants: number;
   ticketPrice: number;
   location: string;
+  locationLat?: number;
+  locationLng?: number;
   date: Date;
   startTime: string;
   duration: number;
@@ -127,6 +130,7 @@ export default function CreateWorkshopForm({
     control,
     trigger,
     watch,
+    setValue,
     formState: { errors },
   } = useForm<FormValues>({ defaultValues });
 
@@ -160,6 +164,8 @@ export default function CreateWorkshopForm({
         ticketPrice: String(data.ticketPrice),
         currency: 'EUR',
         location: data.location,
+        ...(data.locationLat !== undefined && { locationLat: String(data.locationLat) }),
+        ...(data.locationLng !== undefined && { locationLng: String(data.locationLng) }),
         startsAt: startsAt.toISOString(),
         duration: String(data.duration),
         ...(data.level && { level: data.level }),
@@ -374,10 +380,22 @@ export default function CreateWorkshopForm({
 
             <div className="space-y-2">
               <Label htmlFor="location">Location</Label>
-              <Input
-                id="location"
-                placeholder="e.g. Studio Mitte, Berlin"
-                {...register('location', { required: 'Required' })}
+              <Controller
+                name="location"
+                control={control}
+                rules={{ required: 'Required' }}
+                render={({ field }) => (
+                  <LocationAutocomplete
+                    id="location"
+                    placeholder="e.g. Studio Mitte, Berlin"
+                    value={field.value ?? ''}
+                    onChange={field.onChange}
+                    onCoordinatesChange={(lat, lng) => {
+                      setValue('locationLat', lat);
+                      setValue('locationLng', lng);
+                    }}
+                  />
+                )}
               />
               {errors.location && (
                 <p className="text-sm text-destructive">

--- a/frontend/components/workshops/EditWorkshopForm.tsx
+++ b/frontend/components/workshops/EditWorkshopForm.tsx
@@ -13,6 +13,7 @@ import type { Workshop, ConductorProfile } from '@skillity/shared';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import LocationAutocomplete from '@/components/ui/location-autocomplete';
 import { Calendar } from '@/components/ui/calendar';
 import {
   Popover,
@@ -41,6 +42,8 @@ interface FormValues {
   maxParticipants: number;
   ticketPrice: number;
   location: string;
+  locationLat?: number;
+  locationLng?: number;
   date: Date;
   startTime: string;
   duration: number;
@@ -67,6 +70,7 @@ export default function EditWorkshopForm({
     register,
     handleSubmit,
     control,
+    setValue,
     formState: { errors },
   } = useForm<FormValues>({
     defaultValues: {
@@ -108,6 +112,8 @@ export default function EditWorkshopForm({
         maxParticipants: String(data.maxParticipants),
         ...(!isPublished && { ticketPrice: String(data.ticketPrice) }),
         location: data.location,
+        ...(data.locationLat !== undefined && { locationLat: String(data.locationLat) }),
+        ...(data.locationLng !== undefined && { locationLng: String(data.locationLng) }),
         startsAt: startsAt.toISOString(),
         duration: String(data.duration),
       },
@@ -309,10 +315,22 @@ export default function EditWorkshopForm({
 
       <div className="space-y-2">
         <Label htmlFor="location">Location</Label>
-        <Input
-          id="location"
-          {...register('location', { required: 'Required' })}
-          placeholder="Berlin, Germany"
+        <Controller
+          name="location"
+          control={control}
+          rules={{ required: 'Required' }}
+          render={({ field }) => (
+            <LocationAutocomplete
+              id="location"
+              placeholder="Berlin, Germany"
+              value={field.value ?? ''}
+              onChange={field.onChange}
+              onCoordinatesChange={(lat, lng) => {
+                setValue('locationLat', lat);
+                setValue('locationLng', lng);
+              }}
+            />
+          )}
         />
         {errors.location && (
           <p className="text-sm text-destructive">{errors.location.message}</p>

--- a/packages/shared/src/types/workshop.ts
+++ b/packages/shared/src/types/workshop.ts
@@ -70,6 +70,8 @@ export interface Workshop {
   ticketPrice: number;
   currency: string;
   location: string;
+  locationLat: number | null;
+  locationLng: number | null;
   startsAt: string;
   endsAt: string;
   level: WorkshopLevel | null;
@@ -95,6 +97,8 @@ export interface CreateWorkshopInput {
   ticketPrice: number;
   currency: string;
   location: string;
+  locationLat?: number;
+  locationLng?: number;
   startsAt: string;
   duration: number;
   level?: WorkshopLevel;
@@ -111,6 +115,8 @@ export interface UpdateWorkshopInput {
   ticketPrice?: number;
   currency?: string;
   location?: string;
+  locationLat?: number;
+  locationLng?: number;
   startsAt?: string;
   duration?: number;
   level?: WorkshopLevel;


### PR DESCRIPTION
## Summary
- Adds `LocationAutocomplete` component backed by Nominatim (OpenStreetMap geocoding, free, no API key)
- Replaces plain text input for location in both create and edit workshop forms
- Stores `locationLat` / `locationLng` alongside the display name — coordinates are provider-agnostic so any future map provider (Leaflet, Google Maps, Mapbox) works without re-geocoding
- 500ms debounce, results filtered to Germany (`countrycodes=de`)
- Backend entity, DTO, shared types, and migration updated (nullable columns, no breaking change)

## Notes
- Depends on #122 for the migration CLI fix (branches off main before that lands)

## Test plan
- [ ] Create a workshop — location input should show suggestions after 3+ characters
- [ ] Select a suggestion — field populates with full display name
- [ ] Submit form — `locationLat` and `locationLng` should be stored on the workshop
- [ ] Typing a custom address (not selecting a suggestion) still works — lat/lng will be null